### PR TITLE
Switch to USB keyboard device

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -1,0 +1,23 @@
+# Development Testing
+
+To build and flash:
+
+```bash
+idf.py build
+idf.py flash
+idf.py monitor
+```
+
+If using an ESP32-S3 board:
+
+```bash
+idf.py set-target esp32s3
+idf.py build flash monitor
+```
+
+After flashing, your host should detect a **USB HID Keyboard**.
+
+Use a Bluetooth keyboard and trigger the following combos:
+- Alt+Tab → expect `SEND F13` in the serial output
+- Ctrl+Space → expect `SEND F14`
+- Ctrl+Enter → expect `SEND F15`

--- a/main/keyboard_device.cpp
+++ b/main/keyboard_device.cpp
@@ -1,0 +1,47 @@
+#include "keyboard_device.hpp"
+
+extern "C" {
+#include <tusb.h>
+}
+
+const DeviceInfo KeyboardDevice::device_info{
+    .vid = 0xCafe,
+    .pid = 0x4000,
+    .bcd = 0x0100,
+    .usb_bcd = 0x0200,
+    .manufacturer_name = "Finger563",
+    .product_name = "Keyboard",
+    .serial_number = "0001",
+};
+
+static const uint8_t report_desc[] = {
+    0x05, 0x01, 0x09, 0x06, 0xA1, 0x01, 0x05, 0x07,
+    0x19, 0xE0, 0x29, 0xE7, 0x15, 0x00, 0x25, 0x01,
+    0x75, 0x01, 0x95, 0x08, 0x81, 0x02, 0x95, 0x01,
+    0x75, 0x08, 0x81, 0x01, 0x95, 0x06, 0x75, 0x08,
+    0x15, 0x00, 0x25, 0x65, 0x05, 0x07, 0x19, 0x00,
+    0x29, 0x65, 0x81, 0x00, 0xC0
+};
+
+KeyboardDevice::KeyboardDevice() : GamepadDevice("Keyboard") {}
+
+const DeviceInfo &KeyboardDevice::get_device_info() const { return device_info; }
+
+std::vector<uint8_t> KeyboardDevice::get_report_descriptor() const {
+  return std::vector<uint8_t>(report_desc, report_desc + sizeof(report_desc));
+}
+
+void KeyboardDevice::set_report_data(uint8_t, const uint8_t *data, size_t len) {
+  if (len > sizeof(report_)) len = sizeof(report_);
+  memcpy(report_, data, len);
+}
+
+std::vector<uint8_t> KeyboardDevice::get_report_data(uint8_t) const {
+  return std::vector<uint8_t>(report_, report_ + sizeof(report_));
+}
+
+bool KeyboardDevice::send_report(const uint8_t *data, size_t len) {
+  if (!tud_mounted() || len < 8)
+    return false;
+  return tud_hid_keyboard_report(0, data[0], data + 2);
+}

--- a/main/keyboard_device.cpp
+++ b/main/keyboard_device.cpp
@@ -43,5 +43,9 @@ std::vector<uint8_t> KeyboardDevice::get_report_data(uint8_t) const {
 bool KeyboardDevice::send_report(const uint8_t *data, size_t len) {
   if (!tud_mounted() || len < 8)
     return false;
-  return tud_hid_keyboard_report(0, data[0], data + 2);
+  if (!tud_hid_ready())
+    return false;
+  uint8_t report[8];
+  memcpy(report, data, 8);
+  return tud_hid_keyboard_report(0, report[0], report + 2);
 }

--- a/main/keyboard_device.hpp
+++ b/main/keyboard_device.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vector>
+#include "gamepad_device.hpp"
+
+class KeyboardDevice : public GamepadDevice {
+public:
+  KeyboardDevice();
+
+  const DeviceInfo &get_device_info() const override;
+  uint8_t get_input_report_id() const override { return 1; }
+  std::vector<uint8_t> get_report_descriptor() const override;
+  void set_report_data(uint8_t report_id, const uint8_t *data, size_t len) override;
+  std::vector<uint8_t> get_report_data(uint8_t report_id) const override;
+
+  bool send_report(const uint8_t *data, size_t len);
+
+private:
+  static const DeviceInfo device_info;
+  uint8_t report_[8] = {0};
+};

--- a/main/keycodes.h
+++ b/main/keycodes.h
@@ -1,0 +1,21 @@
+#ifndef KEYCODES_H
+#define KEYCODES_H
+
+#define KEY_TAB 0x2B
+#define KEY_SPACE 0x2C
+#define KEY_ENTER 0x28
+#define KEY_F13 0x68
+#define KEY_F14 0x69
+#define KEY_F15 0x6A
+
+// Modifier bits
+#define MOD_LEFT_CTRL  0x01
+#define MOD_LEFT_SHIFT 0x02
+#define MOD_LEFT_ALT   0x04
+#define MOD_LEFT_GUI   0x08
+#define MOD_RIGHT_CTRL 0x10
+#define MOD_RIGHT_SHIFT 0x20
+#define MOD_RIGHT_ALT  0x40
+#define MOD_RIGHT_GUI  0x80
+
+#endif // KEYCODES_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -81,7 +81,7 @@ void notifyCB(NimBLERemoteCharacteristic *pRemoteCharacteristic, uint8_t *pData,
     }
   }
   // otherwise forward the keyboard report
-  if (tud_mounted()) {
+  if (tud_mounted() && tud_hid_ready()) {
     usb_keyboard->send_report(pData + offset, length - offset);
     static auto &bsp = Bsp::get();
     static bool led_on = false;
@@ -218,7 +218,7 @@ extern "C" void app_main(void) {
     index++;
 
     uint8_t empty_report[8] = {0};
-    if (tud_mounted()) {
+    if (tud_mounted() && tud_hid_ready()) {
       usb_keyboard->send_report(empty_report, sizeof(empty_report));
     } else {
       bsp.led(espp::Rgb(1.0f, 0.0f, 0.0f));

--- a/main/usb.cpp
+++ b/main/usb.cpp
@@ -1,8 +1,9 @@
 #include "usb.hpp"
 #include "bsp.hpp"
+#include "keyboard_device.hpp"
 
 static espp::Logger logger({.tag = "USB"});
-static std::shared_ptr<GamepadDevice> usb_gamepad;
+static std::shared_ptr<KeyboardDevice> usb_keyboard;
 
 // DEUBGGING:
 #if DEBUG_USB
@@ -60,16 +61,16 @@ static uint8_t hid_configuration_descriptor[] = {
 
     // Interface number, string index, boot protocol, report descriptor len, EP In address, size &
     // polling interval
-    TUD_HID_INOUT_DESCRIPTOR(0, 4, HID_ITF_PROTOCOL_NONE, hid_report_descriptor.size(), 0x01, 0x81,
+    TUD_HID_INOUT_DESCRIPTOR(0, 4, HID_ITF_PROTOCOL_KEYBOARD, hid_report_descriptor.size(), 0x01, 0x81,
                              CFG_TUD_HID_EP_BUFSIZE, 1),
 };
 
-void start_usb_gamepad(const std::shared_ptr<GamepadDevice> &gamepad_device) {
-  // store the gamepad device
-  usb_gamepad = gamepad_device;
+void start_usb_keyboard(const std::shared_ptr<KeyboardDevice> &keyboard_device) {
+  // store the keyboard device
+  usb_keyboard = keyboard_device;
 
   // update the usb descriptors
-  const auto &device_info = usb_gamepad->get_device_info();
+  const auto &device_info = usb_keyboard->get_device_info();
   hid_string_descriptor[1] = device_info.manufacturer_name.c_str();
   hid_string_descriptor[2] = device_info.product_name.c_str();
   hid_string_descriptor[3] = device_info.serial_number.c_str();
@@ -79,7 +80,7 @@ void start_usb_gamepad(const std::shared_ptr<GamepadDevice> &gamepad_device) {
   desc_device.bcdUSB = device_info.usb_bcd;
 
   // update the report descriptor
-  hid_report_descriptor = usb_gamepad->get_report_descriptor();
+  hid_report_descriptor = usb_keyboard->get_report_descriptor();
 
   // update the configuration descriptor with the new report descriptor size
   uint8_t updated_hid_configuration_descriptor[] = {
@@ -88,7 +89,7 @@ void start_usb_gamepad(const std::shared_ptr<GamepadDevice> &gamepad_device) {
 
       // Interface number, string index, boot protocol, report descriptor len, EP In address, size &
       // polling interval
-      TUD_HID_INOUT_DESCRIPTOR(0, 4, HID_ITF_PROTOCOL_NONE, hid_report_descriptor.size(), 0x01,
+      TUD_HID_INOUT_DESCRIPTOR(0, 4, HID_ITF_PROTOCOL_KEYBOARD, hid_report_descriptor.size(), 0x01,
                                0x81, CFG_TUD_HID_EP_BUFSIZE, 1),
   };
   std::memcpy(hid_configuration_descriptor, updated_hid_configuration_descriptor,
@@ -110,7 +111,7 @@ void start_usb_gamepad(const std::shared_ptr<GamepadDevice> &gamepad_device) {
   logger.info("USB initialization DONE");
 }
 
-void stop_usb_gamepad() {
+void stop_usb_keyboard() {
   if (tinyusb_driver_uninstall() != ESP_OK) {
     logger.error("Failed to uninstall tinyusb driver");
     return;
@@ -129,6 +130,17 @@ bool send_hid_report(uint8_t report_id, const std::vector<uint8_t> &report) {
   return tud_hid_report(report_id, usb_hid_input_report, usb_hid_input_report_len);
 }
 
+bool send_special_key(uint8_t code) {
+  if (!tud_mounted())
+    return false;
+  uint8_t keycodes[6] = {0};
+  keycodes[0] = code;
+  bool res = tud_hid_keyboard_report(0, 0, keycodes);
+  uint8_t empty[6] = {0};
+  tud_hid_keyboard_report(0, 0, empty);
+  return res;
+}
+
 #if DEBUG_USB
 void set_gui(std::shared_ptr<Gui> gui_ptr) { gui = gui_ptr; }
 #endif
@@ -138,7 +150,7 @@ void set_gui(std::shared_ptr<Gui> gui_ptr) { gui = gui_ptr; }
 extern "C" void tud_mount_cb(void) {
   // Invoked when device is mounted
   logger.info("USB Mounted");
-  auto maybe_transmission = usb_gamepad->on_attach();
+  auto maybe_transmission = usb_keyboard->on_attach();
   if (maybe_transmission.has_value()) {
     auto &[report_id, report] = maybe_transmission.value();
     send_hid_report(report_id, report);
@@ -189,7 +201,7 @@ extern "C" void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id,
     // TODO: pro controller supports feature reports
   } else if (report_type == HID_REPORT_TYPE_OUTPUT) {
     // pass the report along to the currently configured usb gamepad device
-    auto maybe_response = usb_gamepad->on_hid_report(report_id, buffer, bufsize);
+    auto maybe_response = usb_keyboard->on_hid_report(report_id, buffer, bufsize);
 #if DEBUG_USB
     std::string debug_string =
         fmt::format("In: {:02x}, {:02x}, {:02x}", buffer[0], buffer[1], buffer[2]);

--- a/main/usb.cpp
+++ b/main/usb.cpp
@@ -131,13 +131,15 @@ bool send_hid_report(uint8_t report_id, const std::vector<uint8_t> &report) {
 }
 
 bool send_special_key(uint8_t code) {
-  if (!tud_mounted())
+  if (!tud_mounted() || !tud_hid_ready())
     return false;
   uint8_t keycodes[6] = {0};
   keycodes[0] = code;
   bool res = tud_hid_keyboard_report(0, 0, keycodes);
-  uint8_t empty[6] = {0};
-  tud_hid_keyboard_report(0, 0, empty);
+  if (res) {
+    uint8_t empty[6] = {0};
+    tud_hid_keyboard_report(0, 0, empty);
+  }
   return res;
 }
 

--- a/main/usb.hpp
+++ b/main/usb.hpp
@@ -6,6 +6,7 @@
 #include "logger.hpp"
 
 #include "gamepad_device.hpp"
+#include "keyboard_device.hpp"
 
 #include "bsp.hpp"
 
@@ -15,9 +16,10 @@ extern "C" {
 #include <tusb.h>
 }
 
-void start_usb_gamepad(const std::shared_ptr<GamepadDevice> &gamepad_device);
+void start_usb_keyboard(const std::shared_ptr<KeyboardDevice> &keyboard_device);
 bool send_hid_report(uint8_t report_id, const std::vector<uint8_t> &report);
-void stop_usb_gamepad();
+bool send_special_key(uint8_t code);
+void stop_usb_keyboard();
 
 // debugging
 


### PR DESCRIPTION
## Summary
- implement `KeyboardDevice` class for boot keyboard reports
- swap initialization to use `KeyboardDevice`
- forward BLE keyboard reports over USB
- keep combo mapping via `send_special_key`
- document building steps for ESP32‑S3
- fix keyboard combo handling

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856365031688322a64b75492e4ef307